### PR TITLE
hello_marco: misc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,9 @@ dependencies = [
 [[package]]
 name = "hello_marco"
 version = "0.1.0"
+dependencies = [
+ "hello_marco_derive",
+]
 
 [[package]]
 name = "hello_marco_derive"
@@ -198,7 +201,6 @@ version = "0.1.0"
 dependencies = [
  "ctrlc",
  "hello_marco",
- "hello_marco_derive",
  "length",
  "rand",
  "time",

--- a/hello_marco/Cargo.toml
+++ b/hello_marco/Cargo.toml
@@ -4,3 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+hello_marco_derive = { path = "../hello_marco_derive", optional = true }
+
+[features]
+derive = ["dep:hello_marco_derive"]

--- a/hello_marco/src/lib.rs
+++ b/hello_marco/src/lib.rs
@@ -1,3 +1,8 @@
 pub trait HelloMarco {
     fn hello_marco();
 }
+
+// has the same use path as `trait Hello`
+// When used in #[derive(HelloMarco)], refers to this type
+#[cfg(feature = "derive")]
+pub use ::hello_marco_derive::HelloMarco;

--- a/rust_by_practice/Cargo.toml
+++ b/rust_by_practice/Cargo.toml
@@ -37,7 +37,6 @@ time = { version = "^0.3", features = ["local-offset"] }
 rand = "^0.8"
 utf8_slice = "1.0.0"
 twox-hash = "^1.6"
-hello_marco = { path = "../hello_marco" }
-hello_marco_derive = { path = "../hello_marco_derive" }
+hello_marco = { path = "../hello_marco", features = ["derive"] }
 length = { path = "../length" }
 ctrlc = "^3.0"

--- a/rust_by_practice/src/practice/p390_marcos.rs
+++ b/rust_by_practice/src/practice/p390_marcos.rs
@@ -28,8 +28,8 @@ mod tests {
     /// Custom derive marco should be in a proc-marco lib crate, skip.
     #[test]
     fn test_custom_derive_attribute_marcos() {
+        // import both trait and derive procedural marcos named `HelloMarco`
         use hello_marco::HelloMarco;
-        use hello_marco_derive::HelloMarco;
         #[derive(HelloMarco)]
         struct Pancakes;
 


### PR DESCRIPTION
Reexport `hello_marco_derive` in `hello_marco`
Make `hello_marco_derive` an optional feature
Import `hello_marco` with `derive` feature